### PR TITLE
Use cupy.array instead of librmm.device_array

### DIFF
--- a/RecSys2019/FeatureEngineering/pandas/count_encode-pandas.ipynb
+++ b/RecSys2019/FeatureEngineering/pandas/count_encode-pandas.ipynb
@@ -21,12 +21,12 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "import cudf as gd\n",
+    "import cupy as cp\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import os\n",
     "import time\n",
     "import nvstrings\n",
-    "from librmm_cffi import librmm\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
    ]
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "def on_gpu(words,func,arg=None,dtype=np.int32):\n",
-    "    res = librmm.device_array(words.size(), dtype=dtype)\n",
+    "    res = cp.array(words.size(), dtype=dtype)\n",
     "    if arg is None:\n",
     "        cmd = 'words.%s(devptr=res.device_ctypes_pointer.value)'%(func)\n",
     "    else:\n",

--- a/RecSys2019/FeatureEngineering/pandas/create_data_pair_comparison-panda.ipynb
+++ b/RecSys2019/FeatureEngineering/pandas/create_data_pair_comparison-panda.ipynb
@@ -20,13 +20,13 @@
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "import cudf as gd\n",
+    "import cupy as cp\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import xgboost as xgb\n",
     "import os\n",
     "import time\n",
     "import nvstrings\n",
-    "from librmm_cffi import librmm\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
    ]
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "def on_gpu(words,func,arg=None,dtype=np.int32):\n",
-    "    res = librmm.device_array(words.size(), dtype=dtype)\n",
+    "    res = cp.array(words.size(), dtype=dtype)\n",
     "    if arg is None:\n",
     "        cmd = 'words.%s(res.device_ctypes_pointer.value)'%(func)\n",
     "    else:\n",

--- a/RecSys2019/FeatureEngineering/pandas/mtr_encode_comparison-pandas.ipynb
+++ b/RecSys2019/FeatureEngineering/pandas/mtr_encode_comparison-pandas.ipynb
@@ -31,12 +31,12 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "import cudf as gd\n",
+    "import cupy as cp\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import os\n",
     "import time\n",
     "import nvstrings\n",
-    "from librmm_cffi import librmm\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
    ]
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "def on_gpu(words,func,arg=None,dtype=np.int32):\n",
-    "    res = librmm.device_array(words.size(), dtype=dtype)\n",
+    "    res = cp.array(words.size(), dtype=dtype)\n",
     "    if arg is None:\n",
     "        cmd = 'words.%s(devptr=res.device_ctypes_pointer.value)'%(func)\n",
     "    else:\n",

--- a/RecSys2019/FeatureEngineering/pandas/setup_bin_pandas.ipynb
+++ b/RecSys2019/FeatureEngineering/pandas/setup_bin_pandas.ipynb
@@ -24,7 +24,6 @@
     "import os\n",
     "import time\n",
     "import nvstrings\n",
-    "from librmm_cffi import librmm\n",
     "import matplotlib.pyplot as plt\n",
     "from concurrent.futures import ThreadPoolExecutor, wait\n",
     "%matplotlib inline"

--- a/RecSys2019/FeatureEngineering/rapids/count_encode-rapids.ipynb
+++ b/RecSys2019/FeatureEngineering/rapids/count_encode-rapids.ipynb
@@ -21,12 +21,12 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "import cudf as gd\n",
+    "import cupy as cp\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import os\n",
     "import time\n",
     "import nvstrings\n",
-    "from librmm_cffi import librmm\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
    ]
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "def on_gpu(words,func,arg=None,dtype=np.int32):\n",
-    "    res = librmm.device_array(words.size(), dtype=dtype)\n",
+    "    res = cp.array(words.size(), dtype=dtype)\n",
     "    if arg is None:\n",
     "        cmd = 'words.%s(devptr=res.device_ctypes_pointer.value)'%(func)\n",
     "    else:\n",

--- a/RecSys2019/FeatureEngineering/rapids/create_data_pair_comparison-rapids.ipynb
+++ b/RecSys2019/FeatureEngineering/rapids/create_data_pair_comparison-rapids.ipynb
@@ -27,13 +27,13 @@
     "import warnings\n",
     "warnings.filterwarnings(\"ignore\")\n",
     "import cudf as gd\n",
+    "import cupy as cp\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import xgboost as xgb\n",
     "import os\n",
     "import time\n",
     "import nvstrings\n",
-    "from librmm_cffi import librmm\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
    ]
@@ -90,7 +90,7 @@
    "source": [
     "def on_gpu(words,func,arg=None,dtype=np.int64):\n",
     "    \n",
-    "    res = librmm.device_array(words.size(), dtype=dtype)\n",
+    "    res = cp.array(words.size(), dtype=dtype)\n",
     "    if arg is None:\n",
     "        cmd = 'words.%s(res.device_ctypes_pointer.value)'%(func)\n",
     "    else:\n",

--- a/RecSys2019/FeatureEngineering/rapids/mtr_encode_comparison-rapids.ipynb
+++ b/RecSys2019/FeatureEngineering/rapids/mtr_encode_comparison-rapids.ipynb
@@ -31,12 +31,12 @@
     "warnings.filterwarnings(\"ignore\")\n",
     "\n",
     "import cudf as gd\n",
+    "import cupy as cp\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import os\n",
     "import time\n",
     "import nvstrings\n",
-    "from librmm_cffi import librmm\n",
     "import matplotlib.pyplot as plt\n",
     "%matplotlib inline"
    ]
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "def on_gpu(words,func,arg=None,dtype=np.int32):\n",
-    "    res = librmm.device_array(words.size(), dtype=dtype)\n",
+    "    res = cp.array(words.size(), dtype=dtype)\n",
     "    if arg is None:\n",
     "        cmd = 'words.%s(devptr=res.device_ctypes_pointer.value)'%(func)\n",
     "    else:\n",

--- a/RecSys2019/FeatureEngineering/rapids/setup_bin_rapids.ipynb
+++ b/RecSys2019/FeatureEngineering/rapids/setup_bin_rapids.ipynb
@@ -24,7 +24,6 @@
     "import os\n",
     "import time\n",
     "import nvstrings\n",
-    "from librmm_cffi import librmm\n",
     "import matplotlib.pyplot as plt\n",
     "from concurrent.futures import ThreadPoolExecutor, wait\n",
     "%matplotlib inline"

--- a/RecSys2019/Training/helpers.py
+++ b/RecSys2019/Training/helpers.py
@@ -40,8 +40,8 @@ from fastai.callbacks import SaveModelCallback
 from numba import cuda
 import cudf
 import cudf as gd
+import cupy as cp
 import nvstrings
-from librmm_cffi import librmm
 import dask
 from dask.delayed import delayed
 from dask.distributed import as_completed, Client, wait
@@ -156,7 +156,7 @@ class AUROC(Callback):
 ### CUDF pre-processing
 
 def on_gpu(words, func, arg=None, dtype=np.int32):
-    res = librmm.device_array(words.size(), dtype=dtype)
+    res = cp.array(words.size(), dtype=dtype)
     if arg is None:
         cmd = 'words.%s(res.device_ctypes_pointer.value)' % (func)
     else:

--- a/RecSys2019/Training/preproc.py
+++ b/RecSys2019/Training/preproc.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import nvstrings, nvcategory
 import warnings
 import cudf
+import cupy as cp
 import pyarrow.parquet as pq
 import pdb
 import torch
@@ -16,10 +17,7 @@ import glob
 from fastai import *
 from fastai.basic_data import *
 from fastai.core import *
-from librmm_cffi import librmm
 
-
-from librmm_cffi import librmm
 from time import time
 from torch import tensor
 
@@ -82,7 +80,7 @@ class MyLabelEncoder(object):
         self._cats = nvcategory.from_strings(y.data)
 
         self._fitted = True
-        arr: librmm.device_array = librmm.device_array(
+        arr: cp.array = cp.array(
             y.data.size(), dtype=np.int32
         )
         self._cats.values(devptr=arr.device_ctypes_pointer.value)


### PR DESCRIPTION
device_array is being removed from RMM https://github.com/rapidsai/rmm/issues/180
Switch to use a cupy for on device array's instead.